### PR TITLE
Bump python from 3.8.2-alpine to 3.8.6-alpine in /scripts

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.2-alpine
+FROM python:3.8.6-alpine
 
 WORKDIR /usr/src/scripts
 


### PR DESCRIPTION
Bumps python from 3.8.2-alpine to 3.8.6-alpine.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>